### PR TITLE
`CHANGE` support

### DIFF
--- a/src/SubscribesUsers.js
+++ b/src/SubscribesUsers.js
@@ -1,35 +1,12 @@
 'use strict';
 
 const async = require('async');
-const {SubscriptionRequest} = require('../src/objects');
 const logger = require('./logger');
-
-// fn is a function with signature:
-//  - (callback)
-//  - (argument, callback)
-//
-// In first case, we just return fn.
-// In second case, we guard against <argument> being null by invoking
-//   callback(null, null)
-// in that case.
-//
-// Callback is expected to have signature (error, result).
-const guardVsNull = (fn) => {
-  switch (fn.length) {
-    case 1:
-      return fn;
-
-    case 2:
-      return (arg, cb) => {
-        return (arg === null)
-          ? process.nextTick(cb, null, null)
-          : fn(arg, cb);
-      };
-
-    default:
-      throw new Error(`fn() has unsupported number of arguments (${fn.length})`);
-  }
-};
+const {
+  createAction,
+  IgnoreAction,
+  SubscribeAction
+} = require('./actions');
 
 class SubscribesUsers {
   constructor ({
@@ -47,30 +24,26 @@ class SubscribesUsers {
   }
 
   process (event, callback) {
-    const request = SubscriptionRequest.fromEvent(
-      event,
-      {allowedFromValues: this.allowedFromValues}
-    );
+    const action = createAction(event);
 
-    const steps = [
-      (cb) => { // We need `request` in scope for `write()`, so nullify it inside.
-        if (request instanceof SubscriptionRequest.IgnoredEventError) {
-          logger.info(request, `Event(id=${event.id}) ignored`);
-          return cb(null, null);
-        }
+    switch (action.constructor) {
+      case SubscribeAction:
+        async.waterfall([
+          this.mailchimp.subscribe.bind(this.mailchimp, this.mailchimpListId, action),
+          (subInfo, cb) => this.usermeta.write(
+            action.userId,
+            this.metaKey,
+            JSON.stringify(subInfo),
+            cb
+          )
+        ], (err, metaReply) => callback(err));
+        break;
 
-        cb(null, request);
-      },
-      (req, cb) => this.mailchimp.subscribe(this.mailchimpListId, req, cb),
-      (info, cb) => this.usermeta.write(
-        request.userId,
-        this.metaKey,
-        JSON.stringify(info),
-        (err, res) => cb(err)
-      )
-    ].map(guardVsNull);
-
-    async.waterfall(steps, callback);
+      case IgnoreAction:
+        logger.info({event, action}, `Event(id=${event.id}) resulted in ${action.constructor.name}: ${action.reason}`);
+        setImmediate(callback, null, null);
+        break;
+    }
   }
 }
 

--- a/src/SubscribesUsers.js
+++ b/src/SubscribesUsers.js
@@ -1,11 +1,14 @@
 'use strict';
 
 const async = require('async');
+const lodash = require('lodash');
 const logger = require('./logger');
+const {SubscriptionInfo} = require('./objects');
 const {
   createAction,
   IgnoreAction,
-  SubscribeAction
+  SubscribeAction,
+  UpdateEmailAction
 } = require('./actions');
 
 class SubscribesUsers {
@@ -23,6 +26,28 @@ class SubscribesUsers {
     this.allowedFromValues = allowedFromValues;
   }
 
+  readSubscription (userId, cb) {
+    this.usermeta.read(userId, this.metaKey, (err, data) => {
+      if (err)
+        return cb(err);
+
+      const info = lodash.get(data, `${userId}.${this.metaKey}`, false);
+
+      return info
+        ? cb(null, new SubscriptionInfo(JSON.parse(info)))
+        : cb(new Error(`User \`${userId}\` has no subscription info saved`));
+    });
+  }
+
+  saveSubscription (userId, subscriptionInfo, cb) {
+    this.usermeta.write(
+      userId,
+      this.metaKey,
+      JSON.stringify(subscriptionInfo),
+      cb
+    );
+  }
+
   process (event, callback) {
     const action = createAction(event);
 
@@ -30,12 +55,15 @@ class SubscribesUsers {
       case SubscribeAction:
         async.waterfall([
           this.mailchimp.subscribe.bind(this.mailchimp, this.mailchimpListId, action),
-          (subInfo, cb) => this.usermeta.write(
-            action.userId,
-            this.metaKey,
-            JSON.stringify(subInfo),
-            cb
-          )
+          this.saveSubscription.bind(this, action.userId)
+        ], (err, metaReply) => callback(err));
+        break;
+
+      case UpdateEmailAction:
+        async.waterfall([
+          this.readSubscription.bind(this, action.userId),
+          (subscription, cb) => this.mailchimp.updateSubscription(subscription, action, cb),
+          this.saveSubscription.bind(this, action.userId)
         ], (err, metaReply) => callback(err));
         break;
 

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,0 +1,74 @@
+'use strict';
+
+const util = require('util');
+const lodash = require('lodash');
+
+class Action {
+  constructor (event, ...messageArgs) {
+    this.event = event;
+    this.reason = util.format(...messageArgs);
+  }
+}
+
+class IgnoreAction extends Action {
+  constructor (event, badField, badValue) {
+    super(event, 'Ignoring `event.%s` value of `%s`', badField, util.inspect(badValue));
+  }
+}
+
+class SubscribeAction extends Action {
+  constructor (event, {userId, email, from: fromValue, metadata}) {
+    super(event, 'Received `%s` event from `%s` with user `%s <%s>`', event.type, fromValue, userId, email);
+    this.userId = userId;
+    this.email = email;
+    this.from = fromValue;
+    this.metadata = metadata;
+  }
+}
+
+class UpdateEmailAction extends SubscribeAction {}
+
+const createAction = (event = {}, {allowedFromValues = null} = {}) => {
+  switch (event.type) {
+    case 'CREATE':
+    case 'CHANGE': {
+      const fromValue = lodash.get(event, 'from');
+      const userId = lodash.get(event, 'data.userId');
+      const email = lodash.get(event, 'data.aliases.email');
+      const newsletter = lodash.get(event, 'data.metadata.newsletter', true);
+
+      if (!fromValue || (allowedFromValues && !allowedFromValues.includes(event.from)))
+        return new IgnoreAction(event, 'from', fromValue);
+
+      if (!userId)
+        return new IgnoreAction(event, 'data.userId', userId);
+
+      if (!email)
+        return new IgnoreAction(event, 'data.aliases.email', email);
+
+      if (!newsletter)
+        return new IgnoreAction(event, 'data.metadata.newsletter', newsletter);
+
+      const ctor = event.type === 'CREATE'
+        ? SubscribeAction
+        : UpdateEmailAction;
+
+      return new ctor(event, {
+        userId,
+        email,
+        from: fromValue,
+        metadata: lodash.get(event, 'data.metadata', {})
+      });
+    }
+
+    default:
+      return new IgnoreAction(event, 'type', event.type);
+  }
+};
+
+module.exports = {
+  createAction,
+  IgnoreAction,
+  SubscribeAction,
+  UpdateEmailAction
+};

--- a/src/apis/MailchimpClient.js
+++ b/src/apis/MailchimpClient.js
@@ -3,8 +3,8 @@
 const assert = require('assert');
 const urlEscape = require('url-escape-tag');
 const BaseClient = require('./BaseClient');
-const {MailchimpPayload} = require('../objects');
-const {SubscribeAction} = require('../actions');
+const {MailchimpPayload, SubscriptionInfo} = require('../objects');
+const {SubscribeAction, UpdateEmailAction} = require('../actions');
 const logger = require('../logger');
 
 const toBase64 = (str) => Buffer.from(str, 'utf8').toString('base64');
@@ -15,6 +15,19 @@ class MailchimpClient extends BaseClient {
       userAgent: clientId,
       headers: {'authorization': `Basic ${toBase64(`${clientId}:${apiKey}`)}`}
     });
+  }
+
+  _createCallback (listId, payload, callback) {
+    return (err, reply) => {
+      if (err)
+        return callback(err);
+
+      const problems = payload.detectProblems(reply);
+      if (problems.hasProblems)
+        logger.warn(problems, `Problems detected with Merge Tags of mailchimp list ${listId}`);
+
+      callback(null, payload.toSubscriptionInfo(reply));
+    };
   }
 
   subscribe (listId, request, callback) {
@@ -31,6 +44,22 @@ class MailchimpClient extends BaseClient {
 
       callback(null, payload.toSubscriptionInfo(reply));
     });
+  }
+
+  updateSubscription (subscription, action, callback) {
+    assert(subscription instanceof SubscriptionInfo);
+    assert(action instanceof UpdateEmailAction);
+    assert(subscription.type === 'mailchimp');
+
+    const path = `/lists/${subscription.listId}/members/${subscription.subscriptionId}`;
+    const payload = new MailchimpPayload(action);
+    const cb = this._createCallback(subscription.listId, payload, callback);
+
+    // We do not update `status` to `subscribe`, since user may have unsubscribed
+    // and changing that without his permission would not be too nice.
+    assert(delete payload.status);
+
+    this.apiCall('patch', path, payload, cb);
   }
 }
 

--- a/src/apis/MailchimpClient.js
+++ b/src/apis/MailchimpClient.js
@@ -1,8 +1,10 @@
 'use strict';
 
+const assert = require('assert');
 const urlEscape = require('url-escape-tag');
 const BaseClient = require('./BaseClient');
 const {MailchimpPayload} = require('../objects');
+const {SubscribeAction} = require('../actions');
 const logger = require('../logger');
 
 const toBase64 = (str) => Buffer.from(str, 'utf8').toString('base64');
@@ -16,6 +18,7 @@ class MailchimpClient extends BaseClient {
   }
 
   subscribe (listId, request, callback) {
+    assert(request instanceof SubscribeAction);
     const payload = new MailchimpPayload(request);
 
     this.apiCall('post', urlEscape`/lists/${listId}/members`, payload, (err, reply) => {

--- a/src/apis/UsermetaClient.js
+++ b/src/apis/UsermetaClient.js
@@ -9,6 +9,14 @@ class UsermetaClient extends BaseClient {
     this.secret = secret;
   }
 
+  read (userId, metaNames, callback) {
+    const token = `${this.secret}.${userId}`;
+    const keys = Array.isArray(metaNames) ? metaNames : [metaNames];
+    const path = urlEscape`/auth/${token}/${keys.join(',')}`;
+
+    this.apiCall('get', path, callback);
+  }
+
   write (userId, metaName, value, callback) {
     const token = `${this.secret}.${userId}`;
     const path = urlEscape`/auth/${token}/${metaName}`;

--- a/tests/actions.test.js
+++ b/tests/actions.test.js
@@ -1,0 +1,103 @@
+'use strict';
+
+const {createAction, SubscribeAction, UpdateEmailAction, IgnoreAction} = require('../src/actions');
+
+describe('actions', () => {
+  describe('createAction()', () => {
+    it('creates SubscribeAction from valid CREATE events', () => {
+      const event = {
+        type: 'CREATE',
+        from: 'service',
+        data: {
+          userId: 'bob',
+          aliases: {email: 'bob@example.com'}
+        }
+      };
+
+      const action = createAction(event);
+
+      expect(action).to.be.instanceof(SubscribeAction);
+      expect(action).to.eql({
+        event,
+        reason: 'Received `CREATE` event from `service` with user `bob <bob@example.com>`',
+        userId: 'bob',
+        email: 'bob@example.com',
+        from: 'service',
+        metadata: {}
+      });
+    });
+
+    it('creates UpdateEmailAction from valid CHANGE events', () => {
+      const event = {
+        type: 'CHANGE',
+        from: 'service',
+        data: {
+          userId: 'bob',
+          aliases: {email: 'bob@new-hip-server.com'},
+          metadata: {letsPutSomethingHere: 'okay'}
+        }
+      };
+
+      const action = createAction(event);
+
+      expect(action).to.be.instanceof(UpdateEmailAction);
+      expect(action).to.eql({
+        event,
+        reason: 'Received `CHANGE` event from `service` with user `bob <bob@new-hip-server.com>`',
+        userId: 'bob',
+        email: 'bob@new-hip-server.com',
+        from: 'service',
+        metadata: {letsPutSomethingHere: 'okay'}
+      });
+    });
+
+    it('ignores uknown types', () => {
+      const action = createAction({type: 'wierd'});
+      expect(action).to.be.instanceof(IgnoreAction);
+      expect(action.reason).to.equal('Ignoring `event.type` value of `\'wierd\'`');
+    });
+
+    it('ignores invalid from values', () => {
+      const action = createAction({type: 'CREATE'});
+      expect(action).to.be.instanceof(IgnoreAction);
+      expect(action.reason).to.equal('Ignoring `event.from` value of `undefined`');
+    });
+
+    it('supports non-whitelisting from values', () => {
+      const action = createAction({
+        type: 'CREATE',
+        from: 'non-whitelisted'
+      }, {allowedFromValues: ['x', 'y']});
+
+      expect(action).to.be.instanceof(IgnoreAction);
+      expect(action.reason).to.equal('Ignoring `event.from` value of `\'non-whitelisted\'`');
+    });
+
+    it('ignores invalid userId', () => {
+      const action = createAction({type: 'CREATE', from: 'service'});
+      expect(action).to.be.instanceof(IgnoreAction);
+      expect(action.reason).to.equal('Ignoring `event.data.userId` value of `undefined`');
+    });
+
+    it('ignores invalid emails', () => {
+      const action = createAction({type: 'CREATE', from: 'service', data: {userId: 'bob'}});
+      expect(action).to.be.instanceof(IgnoreAction);
+      expect(action.reason).to.equal('Ignoring `event.data.aliases.email` value of `undefined`');
+    });
+
+    it('ignores events when metadata.newsletter is set to false', () => {
+      const action = createAction({
+        type: 'CREATE',
+        from: 'service',
+        data: {
+          userId: 'bob',
+          aliases: {email: 'bob@example.com'},
+          metadata: {newsletter: false}
+        }
+      });
+
+      expect(action).to.be.instanceof(IgnoreAction);
+      expect(action.reason).to.equal('Ignoring `event.data.metadata.newsletter` value of `false`');
+    });
+  });
+});

--- a/tests/apis/MailchimpClient.test.js
+++ b/tests/apis/MailchimpClient.test.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const url = require('url');
-const {createAction} = require('../../src/actions');
-const {SubscriptionInfo} = require('../../src/objects');
+const {SubscribeAction} = require('../../src/actions');
+const {SubscriptionInfo, MailchimpPayload} = require('../../src/objects');
 const MailchimpClient = require('../../src/apis/MailchimpClient');
 
 describe('MailchimpClient', () => {
@@ -26,7 +26,7 @@ describe('MailchimpClient', () => {
 
   describe('#subscribe()', () => {
     it('uses SubscribeAction to subscribe user to listId', (done) => {
-      const req = createAction({
+      const req = new SubscribeAction({}, {
         userId: 'bob',
         email: 'bob@example.com',
         from: 'some-app',
@@ -35,15 +35,22 @@ describe('MailchimpClient', () => {
 
       td.replace(client.api, 'post', td.function());
 
-      td.when(client.api.post('/3.0/lists/deadbeef/members', td.matchers.anything(), td.callback))
+      td.when(client.api.post('/3.0/lists/deadbeef/members', td.matchers.isA(MailchimpPayload), td.callback))
         .thenCallback(null, {}, {}, {
-          // Otherwise #detectProblems() throws…
-          merge_fields: {}
+          id: 'sub-id',
+          list_id: 'deadbeef',
+          merge_fields: {G_VIA: 'some-app'}
         });
 
       client.subscribe('deadbeef', req, (err, info) => {
         expect(err).to.be.null;
         expect(info).to.be.instanceof(SubscriptionInfo);
+        expect(info).to.eql({
+          type: 'mailchimp',
+          listId: 'deadbeef',
+          subscriptionId: 'sub-id',
+          G_VIA: 'some-app'
+        });
         done();
       });
     });

--- a/tests/apis/MailchimpClient.test.js
+++ b/tests/apis/MailchimpClient.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const url = require('url');
-const {SubscribeAction} = require('../../src/actions');
+const {SubscribeAction, UpdateEmailAction} = require('../../src/actions');
 const {SubscriptionInfo, MailchimpPayload} = require('../../src/objects');
 const MailchimpClient = require('../../src/apis/MailchimpClient');
 
@@ -50,6 +50,45 @@ describe('MailchimpClient', () => {
           listId: 'deadbeef',
           subscriptionId: 'sub-id',
           G_VIA: 'some-app'
+        });
+        done();
+      });
+    });
+  });
+
+  describe('#updateSubscription()', () => {
+    it('uses UpdateEmailAction to update subscribers email in listId', (done) => {
+      const action = new UpdateEmailAction({}, {
+        userId: 'bob',
+        email: 'bob@new-hip-server.com',
+        from: 'service',
+        metadata: {}
+      });
+
+      const subscription = new SubscriptionInfo({
+        type: 'mailchimp',
+        listId: 'list-id',
+        subscriptionId: 'sub-id',
+        G_VIA: 'w/ever'
+      });
+
+      td.replace(client.api, 'patch', td.function());
+
+      td.when(client.api.patch('/3.0/lists/list-id/members/sub-id', td.matchers.isA(MailchimpPayload), td.callback))
+        .thenCallback(null, {}, {}, {
+          id: 'sub-id',
+          list_id: 'deadbeef',
+          merge_fields: {G_VIA: 'service'}
+        });
+
+      client.updateSubscription(subscription, action, (err, info) => {
+        expect(err).to.be.null;
+        expect(info).to.be.instanceof(SubscriptionInfo);
+        expect(info).to.eql({
+          type: 'mailchimp',
+          listId: 'deadbeef',
+          subscriptionId: 'sub-id',
+          G_VIA: 'service'
         });
         done();
       });

--- a/tests/apis/MailchimpClient.test.js
+++ b/tests/apis/MailchimpClient.test.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const url = require('url');
-const {SubscriptionRequest, SubscriptionInfo} = require('../../src/objects');
+const {createAction} = require('../../src/actions');
+const {SubscriptionInfo} = require('../../src/objects');
 const MailchimpClient = require('../../src/apis/MailchimpClient');
 
 describe('MailchimpClient', () => {
@@ -24,8 +25,8 @@ describe('MailchimpClient', () => {
   });
 
   describe('#subscribe()', () => {
-    it('uses subscription request to subscribe user to listId', (done) => {
-      const req = new SubscriptionRequest({
+    it('uses SubscribeAction to subscribe user to listId', (done) => {
+      const req = createAction({
         userId: 'bob',
         email: 'bob@example.com',
         from: 'some-app',

--- a/tests/apis/UsermetaClient.test.js
+++ b/tests/apis/UsermetaClient.test.js
@@ -3,6 +3,27 @@
 const UsermetaClient = require('../../src/apis/UsermetaClient');
 
 describe('UsermetaClient', () => {
+  it('#read()', (done) => {
+    const client = new UsermetaClient({
+      protocol: 'https',
+      hostname: 'localhost',
+      port: 443,
+      pathnamePrefix: '/usermeta/v1',
+      secret: 'secret'
+    });
+
+    td.replace(client.api, 'get', td.function());
+
+    td.when(client.api.get('/usermeta/v1/auth/secret.bob/key1%2Ckey2', td.callback))
+      .thenCallback(null, {}, {}, {userId: {metaName: 'json string'}});
+
+    client.read('bob', ['key1', 'key2'], (err, res) => {
+      expect(err).to.be.null;
+      expect(res).to.eql({userId: {metaName: 'json string'}});
+      done();
+    });
+  });
+
   it('#write()', (done) => {
     const client = new UsermetaClient({
       protocol: 'https',

--- a/tests/objects.test.js
+++ b/tests/objects.test.js
@@ -1,90 +1,12 @@
 'use strict';
 
-const lodash = require('lodash');
 const samples = require('./samples');
-const {
-  SubscriptionRequest,
-  SubscriptionInfo,
-  MailchimpPayload
-} = require('../src/objects');
+const {SubscribeAction} = require('../src/actions');
+const {SubscriptionInfo, MailchimpPayload} = require('../src/objects');
 
 describe('objects', () => {
-  describe('SubscriptionRequest', () => {
-    describe('.fromEvent()', () => {
-      const event = (overrides) => lodash.merge({
-        channel: 'users/v1',
-        type: 'CREATE',
-        from: 'app that user registred from',
-        data: {
-          userId: 'alice',
-          aliases: {
-            email: 'alice@wonderland.com'
-          },
-          metadata: {
-            some: 'stuff'
-          }
-        }
-      }, overrides);
-
-      it('creates SubscriptionInfo event', () => {
-        expect(SubscriptionRequest.fromEvent(event())).to.eql({
-          userId: 'alice',
-          email: 'alice@wonderland.com',
-          from: 'app that user registred from',
-          metadata: {
-            some: 'stuff'
-          }
-        });
-      });
-
-      it('gracefuly works around missing metadata', () => {
-        const e = event();
-        delete e.data.metadata;
-        expect(SubscriptionRequest.fromEvent(e).metadata).to.eql({});
-      });
-
-      describe('returns IgnoredEventError', () => {
-        const mustBeError = (actual, re) => {
-          expect(actual).to.be.instanceof(SubscriptionRequest.IgnoredEventError);
-          expect(actual.message).to[re instanceof RegExp ? 'match' : 'equal'](re);
-        };
-
-        it('if `type` is not CREATE', () => {
-          mustBeError(
-            SubscriptionRequest.fromEvent(event({type: 'x'})),
-            '`event.type` "x" is ignored'
-          );
-        });
-
-        it('if `from` does not match any of allowedFromValues', () => {
-          mustBeError(
-            SubscriptionRequest.fromEvent(event(), {allowedFromValues: ['something else']}),
-            /^`event\.from` does not match any of allowed values/
-          );
-        });
-
-        it('if `data.aliases.email` is malformed or missing', () => {
-          const e = event();
-          assert(delete e.data.aliases.email);
-          mustBeError(
-            SubscriptionRequest.fromEvent(e),
-            /^`event\.data\.aliases\.email` is malformed or missing/
-          );
-        });
-
-        it('if `data.metadata.newsletter` is false', () => {
-          const e = event({data: {metadata: {newsletter: false}}});
-          mustBeError(
-            SubscriptionRequest.fromEvent(e),
-            '`event.data.metadata.newsletter` is false'
-          );
-        });
-      });
-    });
-  });
-
   describe('MailchimpPayload', () => {
-    const request = new SubscriptionRequest({
+    const action = new SubscribeAction({}, {
       userId: 'alice',
       email: 'alice@wonderland.com',
       from: 'app',
@@ -95,10 +17,10 @@ describe('objects', () => {
       }
     });
 
-    const payload = new MailchimpPayload(request);
+    const payload = new MailchimpPayload(action);
 
     describe('new MailchimpPayload()', () => {
-      it('correctly initialized from request', () => {
+      it('correctly initialized from action', () => {
         expect(payload).to.eql({
           email_address: 'alice@wonderland.com',
           status: 'subscribed',


### PR DESCRIPTION
Ref #9 

Everything stays the same for subscription. When `CHANGE` event arrives that has `aliases.email`, we will try to change member's `email_address` in the list. Also some metadata will get updated (`G_VIA`, etc.) if it is included in the event.

I do not resubscribe user, though, so `CREATE -> User unsubscribes -> CHANGE` will update user's email, but won't set his subscription status in the list to active.

Since we do not have any synchronizatino between redis and mailchimp, here's what happens in different scenarios where they are out of sync (some of these are more likely than others):

|          | Redis Only            | Redis + Mailchimp | Mailchimp Only        | None                  |
|----------|-----------------------|-------------------|-----------------------|-----------------------|
| `CREATE` | okay: overwrites meta | `POST` errors     | `POST` errors         | expected scenario     |
| `CHANGE` | `PATCH` errors        | expected scenario | `process(evt)` errors | `process(evt)` errors |

Let me know if we need some of those fixed. There is also a hard process crash when redis subscription info is not of `mailchimp` type (will change later, or when we add another service, if ever).

<hr/>

Also, some events might get skipped on crashes, but this is `events.Client` issue, though I am not sure if we need/can solve it without adding actual ACK requests at which point we'll be better off incorporating ZeroMQ anyways: 

  1. event emitted
  1. some async stuff starts
  1. event client sends new request (which is ack)
  1. process crashes in a callback of 2
  1. **result** ack sent, but event was not processed

I believe 3 won't be required if we do not send `since` query string param and rely on `last-fetched:*` redis key.